### PR TITLE
feat(validation): harden request validation; server owns id/owner/tim…

### DIFF
--- a/src/main/java/se/brankoov/todoservice/auth/AuthController.java
+++ b/src/main/java/se/brankoov/todoservice/auth/AuthController.java
@@ -1,6 +1,9 @@
 package se.brankoov.todoservice.auth;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -20,10 +23,19 @@ public class AuthController {
         this.repo = repo; this.encoder = encoder;
     }
 
-    public record RegisterReq(@NotBlank String username, @NotBlank String password) {}
+    public record RegisterReq(
+            @NotBlank
+            @Size(min=3, max=32, message="username must be 3–32 chars")
+            @Pattern(regexp="^[a-zA-Z0-9._-]+$", message="username allows letters, digits, dot, underscore, hyphen")
+            String username,
+
+            @NotBlank
+            @Size(min=8, max=72, message="password must be 8–72 chars")
+            String password
+    ) {}
 
     @PostMapping("/register")
-    public ResponseEntity<Void> register(@RequestBody RegisterReq r, UriComponentsBuilder uri) {
+    public ResponseEntity<Void> register(@Valid @RequestBody RegisterReq r, UriComponentsBuilder uri) {
         // enkel koll – unikt username (fångas även av unique index)
         repo.findByUsername(r.username()).ifPresent(u -> {
             throw new org.springframework.web.server.ResponseStatusException(

--- a/src/main/java/se/brankoov/todoservice/entity/Todo.java
+++ b/src/main/java/se/brankoov/todoservice/entity/Todo.java
@@ -1,25 +1,37 @@
 package se.brankoov.todoservice.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 
 import java.time.Instant;
 
 @Document(collection = "todos")
 public class Todo {
     @Id
+    @JsonProperty(access = READ_ONLY)             // klient ska inte skriva id
     private String id;
 
     @NotBlank(message = "title must not be blank")
+    @Size(max = 100, message = "title max 100 chars")
     private String title;
+
+    @Size(max = 1000, message = "description max 1000 chars")
     private String description;
+
     private boolean completed = false;
 
+    @JsonProperty(access = READ_ONLY)             // sätts från server (ägaren)
     private String owner;
 
+    @JsonProperty(access = READ_ONLY)             // serverstyrda tidsstämplar
     private Instant createdAt = Instant.now();
+
+    @JsonProperty(access = READ_ONLY)
     private Instant updatedAt = Instant.now();
 
     public Todo() {}

--- a/src/main/java/se/brankoov/todoservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/se/brankoov/todoservice/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package se.brankoov.todoservice.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,5 +42,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleGeneric(Exception ex, HttpServletRequest req) {
     var body = new ApiError(Instant.now(), 500, "Internal Server Error", "Unexpected error", req.getRequestURI());
     return ResponseEntity.status(500).body(body);
+  }
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiError> handleConstraintViolations(ConstraintViolationException ex, HttpServletRequest req) {
+    var msg = ex.getConstraintViolations().stream()
+            .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+            .collect(Collectors.joining("; "));
+    var body = new ApiError(Instant.now(), 400, "Bad Request", msg, req.getRequestURI());
+    return ResponseEntity.badRequest().body(body);
   }
 }

--- a/src/main/java/se/brankoov/todoservice/service/TodoService.java
+++ b/src/main/java/se/brankoov/todoservice/service/TodoService.java
@@ -61,8 +61,14 @@ public class TodoService {
         return repository.findByOwner(owner);
     }
 
+    private static String trimOrNull(String s) {
+        return s == null ? null : s.trim();
+    }
+
     public Todo createForOwner(Todo todo, String owner) {
         todo.setOwner(owner);
+        todo.setTitle(trimOrNull(todo.getTitle()));
+        todo.setDescription(trimOrNull(todo.getDescription()));
         todo.setUpdatedAt(Instant.now());
         return repository.save(todo);
     }
@@ -72,8 +78,8 @@ public class TodoService {
             if (!owner.equals(t.getOwner())) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not your todo");
             }
-            t.setTitle(newTodo.getTitle());
-            t.setDescription(newTodo.getDescription());
+            t.setTitle(trimOrNull(newTodo.getTitle()));
+            t.setDescription(trimOrNull(newTodo.getDescription()));
             t.setCompleted(newTodo.isCompleted());
             t.setUpdatedAt(Instant.now());
             return repository.save(t);


### PR DESCRIPTION
Harden input validation + make id/owner/createdAt/updatedAt server-owned, to stop client tampering.